### PR TITLE
Deinitialize worker threads after Configuration onSave

### DIFF
--- a/src/chat/Plugin.mts
+++ b/src/chat/Plugin.mts
@@ -1,7 +1,13 @@
 import VError from "verror";
 
-export class PluginInstance {
-  public reducer?: Awaited<ReturnType<typeof PluginInstance.load>>;
+export type PluginInstance = {
+  initialize: () => Promise<void>;
+  action: (action: unknown) => Promise<void>;
+  read: () => unknown;
+};
+
+export class Plugin {
+  constructor(private reducer: PluginInstance) {}
 
   static load = async (
     path: string,

--- a/src/container.mts
+++ b/src/container.mts
@@ -1,15 +1,15 @@
 import type { WorkerContext } from "./worker.mjs";
-import type { ProcessSignals } from "./signals.mjs";
-import type { EnvironmentSignals } from "./environment.mjs";
-import type { PluginInstance } from "./chat/PluginInstance.mjs";
+import type { ProgramSignals } from "./signals.mjs";
+import type { ConfigurationEvents } from "./environment.mjs";
+import type { Plugin } from "./chat/Plugin.mjs";
 import type { ConfigurationLoader } from "./loader.mjs";
 
 export class Container {
   constructor(
     public worker: WorkerContext,
-    public signals: ProcessSignals,
-    public environment: EnvironmentSignals,
-    public plugin: PluginInstance,
-    public loader: ConfigurationLoader
+    public program: ProgramSignals,
+    public configuration: ConfigurationEvents,
+    public loader: ConfigurationLoader,
+    public plugin: Plugin[]
   ) {}
 }

--- a/src/environment.mts
+++ b/src/environment.mts
@@ -74,7 +74,7 @@ export const coalesce = (varchar: string | null | undefined, value: string) => {
   return varchar;
 };
 
-export class EnvironmentSignals {
+export class ConfigurationEvents {
   public onTwitchEnvironment(input: Partial<typeof TWITCH_ENVIRONMENT>) {
     const clientId =
       input.TWITCH_CLIENT_ID !== TWITCH_ENVIRONMENT.TWITCH_CLIENT_ID;

--- a/src/http/routes/configure/bot.mts
+++ b/src/http/routes/configure/bot.mts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { EnvironmentSignals, TWITCH_BOT } from "../../../environment.mjs";
+import { ConfigurationEvents, TWITCH_BOT } from "../../../environment.mjs";
 import VError from "verror";
 import type { Readable } from "node:stream";
 import { ConfigurationLoader } from "../../../loader.mjs";
@@ -120,14 +120,14 @@ export const bot =
     readable,
     method,
     sec,
-    environment,
+    configuration,
     loader,
     worker,
   }: {
     readable: Readable;
     method: "POST" | "GET";
     sec: Partial<Sec>;
-    environment: EnvironmentSignals;
+    configuration: ConfigurationEvents;
     loader: ConfigurationLoader;
     worker: WorkerContext;
   }) => {
@@ -147,7 +147,7 @@ export const bot =
         });
 
         const { result } = isValidBotConfigurationPost(await json.promise);
-        environment.onBotEnvironment({
+        configuration.onBotEnvironment({
           TWITCH_BOT_NAME: result?.botName ?? TWITCH_BOT.TWITCH_BOT_NAME,
           TWITCH_BOT_ID: result?.botId ?? TWITCH_BOT.TWITCH_BOT_ID,
         });
@@ -156,7 +156,7 @@ export const bot =
 
         // Only reload the server if the request is from this configuration page
         if (sec.fetchDest === "iframe") {
-          await loader.onSave();
+          await loader.onSave(worker);
         } else {
           // Otherwise, send a message to the configure page
           await javascript(() => {

--- a/src/http/routes/configure/broadcaster.mts
+++ b/src/http/routes/configure/broadcaster.mts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
-  EnvironmentSignals,
+  ConfigurationEvents,
   TWITCH_BROADCASTER,
 } from "../../../environment.mjs";
 import VError from "verror";
@@ -139,14 +139,14 @@ export const broadcaster =
     readable,
     method,
     sec,
-    environment,
+    configuration,
     loader,
     worker,
   }: {
     readable: Readable;
     method: "POST" | "GET";
     sec: Partial<Sec>;
-    environment: EnvironmentSignals;
+    configuration: ConfigurationEvents;
     loader: ConfigurationLoader;
     worker: WorkerContext;
   }) => {
@@ -168,7 +168,7 @@ export const broadcaster =
         const { result } = isValidBroadcasterConfigurationPost(
           await json.promise
         );
-        environment.onBroadcasterEnvironment({
+        configuration.onBroadcasterEnvironment({
           TWITCH_BROADCASTER_NAME:
             result?.broadcasterId ?? TWITCH_BROADCASTER.TWITCH_BROADCASTER_ID,
           TWITCH_BROADCASTER_ID:
@@ -180,7 +180,7 @@ export const broadcaster =
 
         // Only reload the server if the request is from this configuration page
         if (sec.fetchDest === "iframe") {
-          await loader.onSave();
+          await loader.onSave(worker);
         } else {
           // Otherwise, send a message to the configure page
           await javascript(() => {

--- a/src/http/routes/configure/index.mts
+++ b/src/http/routes/configure/index.mts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from "node:http";
 import type { ConfigurationLoader } from "../../../loader.mjs";
 import { javascript } from "../../html.mjs";
+import type { WorkerContext } from "../../../worker.mjs";
 
 declare global {
   interface Window {
@@ -19,10 +20,12 @@ export const frontend =
     endpoint,
     method,
     loader,
+    worker,
   }: {
     endpoint: string;
     method: "GET" | "POST";
     loader: ConfigurationLoader;
+    worker: WorkerContext;
   }) => {
     if (endpoint.trim().length > 0) {
       res.writeHead(301, { Location: "/configure" });
@@ -31,7 +34,7 @@ export const frontend =
       switch (method) {
         // @ts-ignore Fallthrough case in switch
         case "POST":
-          await loader.onSave();
+          await loader.onSave(worker);
         case "GET":
           res.writeHead(200, { "Content-Type": "text/html" });
           await javascript(() => {
@@ -55,10 +58,6 @@ export const frontend =
           });
           return res.end(`
       <section>
-      <iframe
-        name="configure_service" 
-        src="/configure/service" 
-      ></iframe>          
     </section>
     <section>
       <iframe 
@@ -73,6 +72,10 @@ export const frontend =
         name="configure_broadcaster" 
         src="/configure/bot" 
       ></iframe>                   
+      <iframe
+        name="configure_service" 
+        src="/configure/service" 
+      ></iframe>          
 </section>
 
     <form

--- a/src/http/routes/configure/service.mts
+++ b/src/http/routes/configure/service.mts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   coalesce,
-  EnvironmentSignals,
+  ConfigurationEvents,
   SERVICE_ENVIRONMENT,
 } from "../../../environment.mjs";
 import VError from "verror";
@@ -135,14 +135,14 @@ export const service =
     readable,
     method,
     sec,
-    environment,
+    configuration,
     loader,
     worker,
   }: {
     readable: Readable;
     method: "POST" | "GET";
     sec: Partial<Sec>;
-    environment: EnvironmentSignals;
+    configuration: ConfigurationEvents;
     loader: ConfigurationLoader;
     worker: WorkerContext;
   }) => {
@@ -172,13 +172,13 @@ export const service =
           String(SERVICE_ENVIRONMENT.SERVER_PORT)
         )}`;
 
-        environment.onServiceEnvironment({
+        configuration.onServiceEnvironment({
           SERVER_URL,
         });
         await ConfigurationLoader.saveAll(loader);
         // Only reload the server if the request is from this configuration page
         if (sec.fetchDest !== "iframe") {
-          await loader.onSave();
+          await loader.onSave(worker);
         } else {
           // Otherwise, send a message to the configure page
           await javascript(() => {

--- a/src/http/routes/configure/twitch.mts
+++ b/src/http/routes/configure/twitch.mts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
-  EnvironmentSignals,
+  ConfigurationEvents,
   TWITCH_ENVIRONMENT,
 } from "../../../environment.mjs";
 import VError from "verror";
@@ -164,14 +164,14 @@ export const twitch =
     readable,
     method,
     sec,
-    environment,
+    configuration,
     loader,
     worker,
   }: {
     readable: Readable;
     method: "POST" | "GET";
     sec: Partial<Sec>;
-    environment: EnvironmentSignals;
+    configuration: ConfigurationEvents;
     loader: ConfigurationLoader;
     worker: WorkerContext;
   }) => {
@@ -191,7 +191,7 @@ export const twitch =
         });
 
         const { result } = isValidTwitchConfigurationPost(await json.promise);
-        environment.onTwitchEnvironment({
+        configuration.onTwitchEnvironment({
           TWITCH_CLIENT_ID:
             result?.clientId ?? TWITCH_ENVIRONMENT.TWITCH_CLIENT_ID,
           TWITCH_CLIENT_SECRET:
@@ -213,7 +213,7 @@ export const twitch =
 
         // Only reload the server if the request is from this configuration page
         if (sec.fetchDest === "iframe") {
-          await loader.onSave();
+          await loader.onSave(worker);
         } else {
           // Otherwise, send a message to the configure page
           await javascript(() => {

--- a/src/http/server.mts
+++ b/src/http/server.mts
@@ -3,7 +3,7 @@ import { TwitchOIDC } from "../twitch/oidc.mts";
 import { extname, join, dirname } from "path";
 import { readFile, stat } from "fs";
 import { authorize } from "./routes/authorize.mjs";
-import { PluginInstance } from "../chat/PluginInstance.mjs";
+import { Plugin } from "../chat/Plugin.mjs";
 import { parsePath } from "ufo";
 import VError from "verror";
 import { URLSearchParams } from "node:url";
@@ -79,29 +79,29 @@ export function httpServer({ entities, container }: HttpServerOptions) {
 
       const params = new URLSearchParams(search);
 
-      if (plugin.reducer === undefined) {
-        plugin.reducer = await PluginInstance.load(name, {
-          reducer:
-            params.get("reducer") ??
-            (() => {
-              throw new VError(
-                {
-                  info: {
-                    params,
-                    name,
-                    url,
-                  },
-                },
-                "Search param 'reducer' is required"
-              );
-            })(),
-        });
-
-        await plugin.reducer.initialize();
-      }
-
-      res.writeHead(200, { "Content-Type": "application/json" });
-      return res.end(JSON.stringify(plugin.reducer.read(), null, 4));
+      // if (plugin.reducer === undefined) {
+      //   plugin.reducer = await Plugin.load(name, {
+      //     reducer:
+      //       params.get("reducer") ??
+      //       (() => {
+      //         throw new VError(
+      //           {
+      //             info: {
+      //               params,
+      //               name,
+      //               url,
+      //             },
+      //           },
+      //           "Search param 'reducer' is required"
+      //         );
+      //       })(),
+      //   });
+      //
+      //   await plugin.reducer.initialize();
+      // }
+      //
+      // res.writeHead(200, { "Content-Type": "application/json" });
+      // return res.end(JSON.stringify(plugin.reducer.read(), null, 4));
     }
 
     // Authentication
@@ -226,8 +226,6 @@ export function httpServer({ entities, container }: HttpServerOptions) {
       if (server.listening) {
         server.closeAllConnections();
         server.close();
-      } else {
-        throw new VError("HTTP server closed");
       }
     },
     configuration: {

--- a/src/logging.mts
+++ b/src/logging.mts
@@ -30,9 +30,7 @@ export const Logger = await Effect.runPromise(
         },
       ]);
 
-      return (yield* logging.logger).withContext({
-        thread: `${isMainThread ? `Main` : `Worker`}`,
-      });
+      return (yield* logging.logger);
     }),
     Context.empty().pipe(withStructuredLogging({}))
   )

--- a/src/signals.mts
+++ b/src/signals.mts
@@ -1,6 +1,6 @@
 import { BroadcastChannel } from "node:worker_threads";
 
-export class ProcessSignals {
+export class ProgramSignals {
   exit: BroadcastChannel = new BroadcastChannel("exit");
   onExit: Promise<void>;
   constructor() {


### PR DESCRIPTION


- ConfigurationLoader onSave deinitializes WorkerContext workers
- IRC and EventSub close() functions to disable reconnect
- WorkerContext.fork() increments an ordinal and appends it to the current thread name
- Renamed EnvironmentSignals to ConfigurationEvents
- Renamed ProcessSignals to ProgramSignals

Closes #9 